### PR TITLE
NPM and browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name" : "wysiwyg.js",
+  "version" : "0.1.0",
+  "description": "wysiwyg contenteditable editor (lightweight + cross browser)",
+  "main": "src/wysiwyg.js",
+  "bugs": {
+    "url" : "https://github.com/wysiwygjs/wysiwyg.js/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/wysiwygjs/wysiwyg.js.git"
+  }
+}

--- a/src/wysiwyg.js
+++ b/src/wysiwyg.js
@@ -570,7 +570,8 @@
     };
 
     // Interface: Create wysiwyg
-    window.wysiwyg = function( option )
+    module = module || {};:w
+    module.exports  = window.wysiwyg = function( option )
     {
         // Options
         option = option || {};

--- a/src/wysiwyg.js
+++ b/src/wysiwyg.js
@@ -570,7 +570,7 @@
     };
 
     // Interface: Create wysiwyg
-    module = module || {};:w
+    module = module || {};
     module.exports  = window.wysiwyg = function( option )
     {
         // Options


### PR DESCRIPTION
add package.json and module.exports to allow for browserify compatibility.