### PR TITLE
Replaced removeProp call

### DIFF
--- a/src/wysiwyg-editor.js
+++ b/src/wysiwyg-editor.js
@@ -114,7 +114,7 @@
             {
                 var html = '<img id="wysiwyg-insert-image" src="" alt=""' + (filename ? ' title="'+html_encode(filename)+'"' : '') + '>';
                 wysiwygeditor.insertHTML( html ).closePopup().collapseSelection();
-                var $image = $('#wysiwyg-insert-image').removeProp('id');
+                var $image = $('#wysiwyg-insert-image').removeAttr('id');
                 if( max_imagesize )
                 {
                     $image.css({maxWidth: max_imagesize[0]+'px',


### PR DESCRIPTION
There is a small issue, when wysiwyg is used with jQuery > 2.0, related to multiple image insert. 

Steps
1. Insert image 
2. Continue typing after image. Cursor should be placed after image
3. Try insert second image 

Expected 
Two images are attached and visible

Actual
First image is replaced by second 

Example
http://jsfiddle.net/mdgrLugL/1/ 

Reason
jQuery > 2.0 doesn't remove attribute id when you call removeProp.


Hmmm. But I can see that all .attr() function calls were changed to .prop(). Can you answer me, what was the reason? Thanks.
